### PR TITLE
feat: Nuevo endpoint para reporte csv de transacciones (conexion a bd "transaction")

### DIFF
--- a/src/application/repositories/mongoose/index-transactions.ts
+++ b/src/application/repositories/mongoose/index-transactions.ts
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose'
+
+mongoose.set('strictQuery', false)
+
+export * from './transactions.client'
+
+/* exports */
+export { Document } from 'mongoose'

--- a/src/application/repositories/mongoose/models-transactions/transaction.transaction.model.ts
+++ b/src/application/repositories/mongoose/models-transactions/transaction.transaction.model.ts
@@ -1,0 +1,88 @@
+import { AppMongooseRepo2 } from '@app/repositories/mongoose/index-transactions'
+import mongoose from 'mongoose';
+import { ETefStatus, ETransactionProcessor, ETransactionStatus, type ITransaction, type TTransactionModel } from './transactions-interface'
+import { customLog } from '@app/utils/util.util'
+import { mask } from '@app/utils/card.util'
+const { Schema, SchemaTypes } = mongoose
+
+const TransactionSchema = new Schema<ITransaction, Record<string, unknown>>({
+  /* regular fields */
+  POS: { type: String, required: false },
+  'ID Transaction': { type: String, required: true },
+  Amount: { type: String, required: true },
+  commerce: { type: SchemaTypes.ObjectId, default: '6427534b564dafe73299a7d8' },
+  type: { type: String },
+  'Application PAN': { type: String, required: true, set: (value: string) => mask(value) },
+  'Cardholder Name': { type: String, required: false },
+  'Cardholder Phone': { type: String, required: false },
+  'Cardholder Email': { type: String, required: false },
+  'Transaction Date': { type: String, required: true },
+  'Transaction Time': { type: String, required: true },
+  'SIC Code': { type: String },
+  'ID Afiliate': { type: String },
+  'Afiliate Number': { type: String },
+  'ID Aggregator': { type: String },
+  'ID Terminal': { type: String },
+  status: { type: String },
+  transactionStatus: { type: String, enum: ETransactionStatus, default: ETransactionStatus.DEFAULT },
+  tefStatus: { type: String, enum: ETefStatus, default: ETefStatus.NA, required: true },
+  'ISO CODE DESCRIPTION': { type: String },
+  'ISO CODE RESPONSE': { type: String },
+  'MIT Fields': [{ type: Object, required: false, default: [] }],
+  reference: { type: String, required: true },
+  'Card Type': { type: String, required: true },
+  'Points BBVA': { type: Boolean, default: false },
+  MSI: { type: Number, default: 0 },
+  SKP: { type: Number, default: 0 },
+  PF: { type: Number, default: 0 },
+
+  epn: { type: String },
+  processorId: { type: String },
+  'IFD Serial Number': { type: String },
+  tlv: { type: String, required: false },
+  tpvModel: { type: String },
+  /* extra fields */
+  latitude: { type: Number },
+  longitude: { type: Number },
+  commerceName: { type: String },
+  tip: { type: Number, default: 0 },
+  bank: { type: String },
+  bankProduct: { type: String },
+  scheme: { type: String },
+  fpmApproved: { type: Boolean },
+  fpmValidationMsg: { type: String },
+  processor: { type: String, enum: ETransactionProcessor, default: ETransactionProcessor.EGLOBAL },
+  _3dsId: { type: String },
+  linkId: { type: String },
+  orderId: { type: String },
+  /* refunds */
+  refundPairId: { type: String },
+  /* backup */
+  originalRequest: { type: String },
+  originalResponse: { type: String },
+  /* AVS */
+  avsId: { type: String },
+
+  origin: { type: String },
+  txnReference: { type: String },
+  /* defaults */
+  createdAt: { type: Date, default: () => Date.now() },
+  updatedAt: { type: Date, default: () => Date.now() },
+  active: { type: Boolean, default: true }
+}, { toJSON: { virtuals: true }, toObject: { virtuals: true } })
+
+/* pre (middlewares) */
+TransactionSchema.pre('save', function (next: any) {
+  this.updatedAt = new Date(Date.now())
+  next()
+})
+
+/* post (middlewares) */
+TransactionSchema.post('save', function (doc) {
+  if (doc.isNew) {
+    customLog(`[Transaction][${String(doc._id)}] Transacción creada: ${JSON.stringify(doc.toJSON())}`)
+  }
+})
+
+/* model instance */
+export const TransactionModelTransaction = AppMongooseRepo2.model<ITransaction, TTransactionModel>('transactions', TransactionSchema)

--- a/src/application/repositories/mongoose/models-transactions/transactions-interface.ts
+++ b/src/application/repositories/mongoose/models-transactions/transactions-interface.ts
@@ -1,0 +1,142 @@
+import { type Document } from '@app/repositories/mongoose/index-transactions'
+import { type Model, type Types } from 'mongoose'
+
+export enum ETransactionType {
+  ECOMMERCE = 'e-commerce',
+  TPV = 'tpv'
+}
+
+export enum ETransactionStatus {
+  DEFAULT = 'n/a',
+  APPROVED = 'approved',
+  DECLINED = 'declined',
+  CANCELLED = 'cancelled',
+  REFUND = 'refund',
+  REVERSED = 'reversed'
+}
+
+export enum ETefStatus {
+  NOT_SENT = 'not-sent',
+  WARNING = 'warning',
+  DECLINED = 'declined',
+  APPROVED = 'approved',
+  NA = 'n/a'
+}
+
+export enum EISOResponseStatus {
+  PENDING = 'Pending - Se hizo la solicitud pero no llegó al ISO',
+  SENT = 'ISO - Solicitud completada con el ISO, es espera de respuesta',
+  SOLVED = 'ISO Response - Respuesta recibida por parte del ISO',
+}
+
+export enum ETransactionProcessor {
+  CYBERSOURCE = 'cybersource',
+  EGLOBAL = 'eglobal',
+  BANORTE = 'banorte',
+  BBVA = 'bbva'
+}
+
+export interface IMITFields {
+  '1'?: string
+  '3'?: string
+  '4'?: string
+  '7'?: string
+  '11'?: string
+  '12'?: string
+  '13'?: string
+  '15'?: string
+  '17'?: string
+  '18'?: string
+  '22'?: string
+  '23'?: string
+  '25'?: string
+  '32'?: string
+  '35'?: string
+  '37'?: string
+  '38'?: string
+  '39'?: string
+  '41'?: string
+  '43'?: string
+  '48'?: string
+  '49'?: string
+  '52'?: string
+  '54'?: string
+  '55'?: string
+  '58'?: string
+  '59'?: string
+  '60'?: string
+  '62'?: string
+  '63'?: string
+  '70'?: string
+  '90'?: string
+  '103'?: string
+}
+
+export interface ITransaction extends Document {
+  _id: Types.ObjectId
+  /* fields */
+  POS: string
+  'ID Transaction': string
+  Amount: string
+  commerce: Types.ObjectId
+  type?: ETransactionType
+  'Application PAN': string
+  'Cardholder Name': string
+  'Cardholder Phone': string
+  'Cardholder Email': string
+  'Transaction Date': string
+  'Transaction Time': string
+  'SIC Code': string
+  'ID Afiliate': string
+  'Afiliate Number': string
+  'ID Aggregator': string
+  'ID Terminal': string
+  status: EISOResponseStatus
+  transactionStatus: ETransactionStatus
+  tefStatus: ETefStatus
+  'ISO CODE DESCRIPTION': string
+  'ISO CODE RESPONSE': string
+  'MIT Fields': IMITFields[]
+  reference: string
+  'Card Type': string
+  'Points BBVA': boolean
+  MSI: number
+  SKP: number
+  PF: number
+
+  epn?: string
+  processorId: string
+  'IFD Serial Number': string
+  tlv?: string
+  tpvModel: string
+  /* extra fields */
+  latitude: number
+  longitude: number
+  commerceName: string
+  tip: number
+  bank: string
+  bankProduct: string
+  scheme: string
+  fpmApproved: boolean
+  fpmValidationMsg: string
+  processor: ETransactionProcessor
+  _3dsId: string
+  linkId: string
+  orderId: string
+  /* refund */
+  refundPairId?: string
+  /* backup */
+  originalRequest: string
+  originalResponse: string
+  /* AVS */
+  avsId: string
+
+  origin: string
+  txnReference: string
+  /* defaults */
+  createdAt?: Date
+  updatedAt?: Date
+  active?: boolean
+}
+
+export type TTransactionModel = Model<ITransaction, Record<string, unknown>>

--- a/src/application/repositories/mongoose/mongoose.settings.ts
+++ b/src/application/repositories/mongoose/mongoose.settings.ts
@@ -1,3 +1,4 @@
 export const AppMongooseSettings = {
-  uri: process.env.MONGODB_URI ?? ''
+  uri: process.env.MONGODB_URI ?? '',
+  uri2: process.env.MONGODB_URI2 ?? '',
 }

--- a/src/application/repositories/mongoose/transactions.client.ts
+++ b/src/application/repositories/mongoose/transactions.client.ts
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose'
+/* settings */
+import { AppMongooseSettings } from './mongoose.settings'
+/* handlers */
+import { Winston } from '@app/handlers/loggers/winston.logger'
+
+const AppMongooseRepo2 = mongoose.createConnection(
+  AppMongooseSettings.uri2,
+)
+
+AppMongooseRepo2.on('error', (e) => { Winston.error(String(e)) })
+AppMongooseRepo2.on('open', () => { Winston.info('transactions db connection success!') })
+
+export {AppMongooseRepo2}

--- a/src/controllers/transaction/services/transaction.service.ts
+++ b/src/controllers/transaction/services/transaction.service.ts
@@ -856,7 +856,7 @@ class TransactionService extends TransactionResumeService {
       .aggregate()
       .match(filter)
       .sort({ 'Transaction Date': -1, 'Transaction Time': -1 })
-      .project({ 'Transaction Date': 1, 'Transaction Time': 1, Amount: 1, comission: 1, commerce: 1, iva: 1, 'ID Transaction': 1, lklpayComission: 1, fixedComission: 1, type: 1, transactionStatus: 1, depositStatus: 1, tefStatus: 1 })
+      .project({ 'Transaction Date': 1, 'Transaction Time': 1, Amount: 1, comission: 1, commerce: 1, iva: 1, 'ID Transaction': 1, lklpayComission: 1, fixedComission: 1, type: 1, transactionStatus: 1, depositStatus: 1, tefStatus: 1, operationType: 1,  RRN: { $getField: { field: "37", input: { $arrayElemAt: ["$MIT Fields", 0] } } } })
       .skip(Number(start))
       .limit(Number(limit))
 

--- a/src/controllers/transaction/transaction.controller.ts
+++ b/src/controllers/transaction/transaction.controller.ts
@@ -402,6 +402,22 @@ class TransactionController {
       return res.status(400).json(error)
     }
   }
+    public async getBackofficeCSVReport (req: Request, res: Response): Promise<AppControllerResponse> {
+    try {
+      const query = req.query
+      const result = await transactionReportService.getBackofficeCSVReport(query)
+      const file = result.file ?? null
+      const fileName: string = result.fileName ?? ''
+      res.set({
+        'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'Content-Disposition': 'attachment; filename="' + fileName + '"'
+      })
+      return res.status(200).send(file)
+    } catch (error) {
+      console.log(error)
+      return res.status(400).json(error)
+    }
+  }
 
   public async getFranchisesReportBackoffice (req: Request, res: Response): Promise<AppControllerResponse> {
     const locals = res.locals; console.log(locals)

--- a/src/routes/transaction.routes.ts
+++ b/src/routes/transaction.routes.ts
@@ -51,6 +51,7 @@ class TransactionRoutes extends ServerRouter {
     this.router.get('/backoffice/transactionsReport2', transactionController.getTransactionsReportBackoffice2 as RequestHandler)
     this.router.get('/backoffice/transactionsReport3', transactionController.getTransactionsReportBackoffice3 as RequestHandler)
     this.router.get('/backoffice/transactionsReport4', transactionController.getTransactionsReportBackoffice4 as RequestHandler)
+    this.router.get('/backoffice/BackofficeCSVReport', transactionController.getBackofficeCSVReport as RequestHandler)
     this.router.get('/backoffice/franchisesReport', transactionController.getFranchisesReportBackoffice as RequestHandler)
     this.router.get('/backoffice/franchisesReport2', transactionController.getFranchisesReportBackoffice2 as RequestHandler)
     this.router.get('/backoffice/monthlyReport', /* [backofficeMiddleware], */ transactionController.getMonthlyReport as RequestHandler)


### PR DESCRIPTION
1. Se creo el nuevo endpoint de reporte que apunta a la bd de "transaction"
     Nota: Agregar en el .env el string de la bd de transacciones con el nombre (MONGODB_URI2).-

2. Agregue 2 campos nuevos al endpoint (/backoffice/getTransactions), el tipo de transacción y el RRN (operationType, MIT Fields [0].37).-