### PR TITLE
feat: corregido filtro de amount para aceptar decimales

### DIFF
--- a/src/controllers/transaction/services/subservices/report.service.ts
+++ b/src/controllers/transaction/services/subservices/report.service.ts
@@ -723,7 +723,7 @@ export class TransactionReportService {
       filter['Application PAN'] = { $regex: new RegExp(`${cardNumber}$`) }
     }
     if (amount != null) {
-      filter.Amount = { $eq: Math.round(amount) }
+      filter.Amount = { $eq: parseFloat(amount) }
     }
     const transactions = await TransactionModel.aggregate([
       { $match: filter },


### PR DESCRIPTION
Durante las pruebas se detectó un pequeño conflicto al aplicar filtros con valores decimales en el campo amount. El valor se estaba redondeando, lo que impedía obtener coincidencias precisas.-