### PR TITLE
feat: reflejar en el mensaje cuando la transacción incluye firma

### DIFF
--- a/src/controllers/transaction/services/reports/tx-voucher-pdf.ts
+++ b/src/controllers/transaction/services/reports/tx-voucher-pdf.ts
@@ -156,7 +156,7 @@ export async function createTxVoucherPdf (transaction: ITransaction, commerce: a
     drawRow('Secuencia:', extractSequence(transaction.tlv) ?? '-----')
     drawRow('AID:', extractAID(transaction.tlv) ?? '-----')
     drawRow('ARQC:', extractARQC(transaction.tlv) ?? '-----')
-    drawRow('AUTORIZADO:', translateReadMode(transaction.readMode))
+    drawRow('AUTORIZADO:', translateReadMode(transaction.readMode, signatureBuffer != null))
     doc.y = posY
 
     // Agregar firma si existe
@@ -262,16 +262,16 @@ function extractSequence (tlv: string | undefined): string | undefined {
   return tlv.substr(index + 6, len * 2)
 }
 
-function translateReadMode (code: string): string {
+function translateReadMode (code: string, hasSignature: boolean = false): string {
   switch (code) {
     case '01':
       return 'Tarjeta digitada'
     case '80':
       return 'Fallback'
     case '05':
-      return 'Autorizado con Chip + NIP'
+      return hasSignature ? 'Chip + firma' : 'Autorizado con Chip + NIP'
     case '07':
-      return 'Autorizado sin contacto'
+      return hasSignature ? 'Autorizado con firma' : 'Autorizado sin contacto'
     default:
       return 'Desconocido'
   }


### PR DESCRIPTION
Adjunto imágenes para los casos posibles. 
**Caso 07 con firma:**
<img width="355" height="701" alt="image" src="https://github.com/user-attachments/assets/d90d9b23-9669-4c22-b406-b6c32f195847" />

**Caso 07 sin firma:**
<img width="354" height="622" alt="image" src="https://github.com/user-attachments/assets/83b9a6d9-6beb-47dc-908d-c4363552a7c2" />

**Se forzó el caso 05 con firma(solo para ver como se vería el pdf):**
<img width="345" height="704" alt="image" src="https://github.com/user-attachments/assets/a82d505c-09a9-4d67-ac3b-c7e75529ebe7" />
